### PR TITLE
Improve RegExp that replaces `sourceMappingURL` comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ RemoveSourceMapURLWebpackPlugin.prototype.onAfterCompile = function(compilation,
   .forEach((key) => {
     countMatchAssets += 1;
     let asset = compilation.assets[key];
-    let source = asset.source().replace(/# sourceMappingURL=(.*\.map)/g, '# $1');
+    let source = asset.source().replace(/# sourceMappingURL=(.+?\.map)/g, '# $1');
     compilation.assets[key] = Object.assign(asset, {
       source: function () { return source }
     });


### PR DESCRIPTION
This PR makes `sourceMappingURL` RegExp lazy instead of greedy because currently this line:
```
//# sourceMappingURL=data:application/json;base64,some other code; //# sourceMappingURL=foo.js
```
will be replaced by this:
```
//# data:application/json;base64,some other code; //# sourceMappingURL=foo.js.map
```
Note that second `sourceMappingURL` is not replaced because RegExp is greedy.