### PR TITLE
Don't show `asset(s) processed` log message if all assets were filtered out

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,11 @@ RemoveSourceMapURLWebpackPlugin.prototype.onAfterCompile = function(compilation,
       source: function () { return source }
     });
   });
-  console.log(colors.green(`remove-source-map-url: ${countMatchAssets} asset(s) processed`));
+
+  if (countMatchAssets) {
+    console.log(colors.green(`remove-source-map-url: ${countMatchAssets} asset(s) processed`));
+  }
+
   cb();
 };
 


### PR DESCRIPTION
Now if your project have a lot of non-js assets like `*.html` templates this plugin spams console with `remove-source-map-url: 0 asset(s) processed` messages. PR fixes this.